### PR TITLE
MX-13099: Enable head installation for monoxer-cocoapods

### DIFF
--- a/Formula/monoxer-cocoapods.rb
+++ b/Formula/monoxer-cocoapods.rb
@@ -5,6 +5,7 @@ class MonoxerCocoapods < Formula
   sha256 "4f494e7651cdf1a7afae6117fb1ed33c919471d7bc3b7575a68d5c316faf567c"
   license "MIT"
   revision 1
+  head "https://github.com/CocoaPods/CocoaPods.git", branch: "master"
 
   bottle do
     root_url "https://github.com/Monoxer/homebrew-monoxer/releases/download/monoxer-cocoapods-1.11.0_1"
@@ -12,6 +13,8 @@ class MonoxerCocoapods < Formula
     sha256                               monterey:      "13bb1729f17cabdab636011b26c0784294d342ef824fc7125bde9708baa46f66"
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "f51c30de88286d37acdcc95bed4134591c8fe49d30806ea31b8825e11db2af9f"
   end
+
+  keg_only "this is a homemade formula"
 
   depends_on "pkg-config" => :build
   depends_on "ruby" if Hardware::CPU.arm?
@@ -26,7 +29,11 @@ class MonoxerCocoapods < Formula
 
     ENV["GEM_HOME"] = libexec
     system "gem", "build", "cocoapods.gemspec"
-    system "gem", "install", "cocoapods-#{version}.gem"
+    if build.head?
+      system "gem", "install", "cocoapods-1.12.1.gem"
+    else
+      system "gem", "install", "cocoapods-#{version}.gem"
+    end
     # Other executables don't work currently.
     bin.install libexec/"bin/pod", libexec/"bin/xcodeproj"
     bin.env_script_all_files(libexec/"bin", GEM_HOME: ENV["GEM_HOME"])


### PR DESCRIPTION
Related MX-13099

Xcode 15でビルドするためにはCocoaPods 1.13.0が必要なのですが、しばらくリリースされない可能性があるので、一旦masterのCocoaPodsを簡単にインストールできるようにする仕組みを導入します。

以下の手順でXcode 15上でビルドできるようになります。

```
brew tap monoxer/monoxer
brew install --head monoxer-cocoapods
brew install python@3.9
export PATH="$(brew --prefix monoxer-cocoapods)/bin:$PATH"

cd ~/Documents/GitHub/monoxer_ios
rm -rf Pods Carthage
pod install
export CLOUDSDK_PYTHON=python3.9
./scripts/rome-download.sh
open mxios.xcworkspace
```